### PR TITLE
Resolve GitHub issue #2

### DIFF
--- a/papertrail.py
+++ b/papertrail.py
@@ -261,7 +261,13 @@ class PaperIndex:
 
         Returns:
             List of (chunk_text, similarity_score) tuples, sorted by relevance.
+
+        Raises:
+            ValueError: If k is less than or equal to 0.
         """
+        if k <= 0:
+            raise ValueError("k must be positive")
+
         model = self._get_embedding_model()
         query_embedding = model.encode([query], convert_to_numpy=True)
         faiss.normalize_L2(query_embedding)
@@ -451,6 +457,10 @@ def main():
     # Validate that at least one action is specified
     if not any([args.mode, args.ask, args.claim]):
         parser.error("Please specify --mode, --ask, or --claim")
+
+    # Validate top-k parameter
+    if args.top_k <= 0:
+        parser.error("--top-k must be a positive integer")
 
     # Check that the paper file exists
     paper_path = Path(args.paper)

--- a/papertrail.py
+++ b/papertrail.py
@@ -266,7 +266,7 @@ class PaperIndex:
             ValueError: If k is less than or equal to 0.
         """
         if k <= 0:
-            raise ValueError("k must be positive")
+            raise ValueError("k must be a positive integer")
 
         model = self._get_embedding_model()
         query_embedding = model.encode([query], convert_to_numpy=True)


### PR DESCRIPTION
Fixes #2

- Add ValueError in PaperIndex.search() when k <= 0
- Add CLI validation for --top-k argument
- Update docstring to document the ValueError exception

This prevents invalid search behavior when k is zero or negative.